### PR TITLE
fix(ci): build workspace libraries before compile and zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build workspace libraries
+        run: pnpm build
+
       - name: Build & zip (Chrome)
         run: pnpm --filter @marimo/extension zip
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ packages/
   notebook-core/        Public API: detect, render, playground URL, types
   extension-runtime/    Reconcile-on-observe controller + switching UI
   host-github/          GitHub.com + gist.github.com implementation
-  host-gitlab/          Placeholder (not yet implemented)
+  host-gitlab/          GitLab.com implementation
 apps/
   extension/            WXT browser extension (Chrome + Firefox)
 ```
@@ -155,7 +155,7 @@ That's it: no changes to the runtime or core.
 
 ## Notes
 
-- The extension's content script runs on `github.com/*` and `gist.github.com/*` only (see `apps/extension/wxt.config.ts`)
+- The extension's content script runs on `github.com/*`, `gist.github.com/*`, and `gitlab.com/*` only (see `apps/extension/wxt.config.ts`)
 - Hosts share the runtime's floating UI switcher (notebook ↔ original code), theme detection, CSP fallback, and reconcile-on-observe logic
-- GitLab host is stubbed; phase 5 of the original plan
+- GitLab host is implemented (`gitlab.com` blobs), fetching raw source same-origin using the user's session
 - Playground ref is `marimo-glance:<surface>` (e.g., `marimo-glance:github`, `marimo-glance:gist`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ The rendering logic is kept separate from the extension so the core stays reusab
 | `@marimo/notebook-core`     | Portable core: detect a notebook, build the playground URL, render the iframe.  |
 | `@marimo/extension-runtime` | Watches the page and mounts the opt-in switcher; survives soft navigations.     |
 | `@marimo/host-github`       | Teaches the runtime about `github.com` blobs and `gist.github.com`.             |
-| `@marimo/host-gitlab`       | Placeholder for GitLab support.                                                 |
+| `@marimo/host-gitlab`       | Teaches the runtime about `gitlab.com` blobs.                                   |
 | `apps/extension`            | The [WXT](https://wxt.dev) extension for Chrome and Firefox.                    |
 
 ### Core invariant: dependency direction

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
       "persistent": true
     },
     "compile": {
-      "dependsOn": ["^compile"],
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "lint": {


### PR DESCRIPTION
The `@marimo/*` packages resolve to their `dist/` output, so `turbo compile` and the extension zip scripts fail on a clean checkout until those libraries are built first. This is why the initial CI run went red.

## Changes
- `turbo.json`: `compile` now depends on `^build` (was `^compile`), so upstream `dist/*.d.ts` exists before typechecking.
- `.github/workflows/ci.yml`: run `pnpm build` before zipping in the extension job.
- Docs: mark the GitLab host as implemented in CONTRIBUTING and AGENTS (it was still described as a placeholder).

## Verification
Both CI jobs reproduce green from a clean checkout (`pnpm clean` then the job steps):
- `pnpm lint` / `pnpm compile` / `pnpm test` — pass
- `pnpm build` → Chrome + Firefox zip → `web-ext lint` (0 errors, 0 warnings)