### PR TITLE
docs: add Chrome Web Store and Firefox Add-on badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Marimo Glance
 
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/emnkplkdlpojjembfbkdagibhmippjfg?label=Chrome%20Web%20Store&logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/emnkplkdlpojjembfbkdagibhmippjfg)
+[![Firefox Add-on](https://img.shields.io/amo/v/marimo-glance?label=Firefox%20Add-on&logo=firefoxbrowser&logoColor=white)](https://addons.mozilla.org/firefox/addon/marimo-glance)
+
 See marimo notebooks at a glance.
 
 marimo notebooks are just Python files, so GitHub and gists show them as source code. This extension detects a notebook and adds a **"Switch to interactive marimo notebook"** button in the bottom-right of the page. Click it and the raw Python is replaced with an interactive WASM notebook. The **"See original"** button switches you back.


### PR DESCRIPTION
Adds store-listing badges to the README header:

- **Chrome Web Store** version badge → `https://chromewebstore.google.com/detail/emnkplkdlpojjembfbkdagibhmippjfg`
- **Firefox Add-on** version badge → `https://addons.mozilla.org/firefox/addon/marimo-glance`

Version/link badges only (no user-count or rating badges).

**Draft until the listings are public.** Both stores are still in review, so the badges currently render as `invalid` / `not found` and the links 404. Mark ready / merge once at least one listing is approved.