### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,36 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # oxlint powers the `lint` task; `--fix` applies its autofixable rules
+      # across the workspace. Unfixable lint errors are CI's job to report;
+      # don't let them block uploading the fixes that did apply.
+      - run: pnpm exec oxlint --fix || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that runs the repo's linter in fix mode on every push to `main` and on pull requests, then uses the [autofix.ci](https://autofix.ci) app to push any resulting fixes back onto the PR branch.

- Workflow `name` is exactly `autofix.ci` — the service identifies the workflow by name for security.
- Fixer command: `pnpm exec oxlint --fix` at the workspace root (the `lint` task is oxlint-powered via turbo). Wrapped in `|| true` so unfixable lint findings never block uploading the fixes that did apply.
- Setup + install steps mirror this repo's own `ci.yml` (checkout v7, pnpm/action-setup, setup-node 24, `pnpm install --frozen-lockfile`). Everything is SHA-pinned with matching `# vX` comments.
- `autofix-ci/action` runs last.

The **autofix.ci GitHub App is installed org-wide** for marimo-team (confirmed by an org admin), so no per-repo app configuration is needed.

## Verification

Cloned, `pnpm install --frozen-lockfile`, ran `pnpm exec oxlint --fix`: no changes — the tree is already clean. Confirmed root oxlint actually scans the workspace by injecting a probe error (caught as expected), so the fixer is not a silent no-op. Workflow validated with `actionlint` (clean). No code changes in this PR — workflow only.

Part of the marimo-team engineering-excellence initiative to standardize autofix across repos.

Do not auto-merge.