### PR TITLE
docs: add CLAUDE.md symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
AGENTS.md already exists here; this adds the org-convention `CLAUDE.md → AGENTS.md` symlink so Claude-family tooling picks up the same doc. Part of the marimo-team engineering-excellence initiative.