### PR TITLE
ci: add a manual release workflow for both stores

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release
+
+# Builds both browser packages, signs the Chrome one, and opens a draft GitHub
+# release carrying everything needed for the two store uploads. Uploading to the
+# Chrome Web Store and Firefox Add-ons stays manual.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build and sign, but create no tag and no release
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  release:
+    name: Build, sign & draft release
+    runs-on: ubuntu-latest
+    # Gates the signing key behind a required reviewer, so it is only readable
+    # from a run that was explicitly approved.
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Tags are needed to tell an already-released version from a new one.
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Resolve version
+        id: version
+        run: |
+          version="$(node -p "require('./apps/extension/package.json').version")"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "tag=v$version" >>"$GITHUB_OUTPUT"
+          echo "Releasing $version"
+
+      # Catches a dispatch that forgot the version bump, before anything is built
+      # or signed, rather than after a store upload is rejected as a duplicate.
+      - name: Check the version is unreleased
+        run: |
+          if git rev-parse -q --verify "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null; then
+            echo "::error::${{ steps.version.outputs.tag }} already exists. Bump the version in apps/extension/package.json first."
+            exit 1
+          fi
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build workspace libraries
+        run: pnpm build
+
+      - name: Build & zip (Chrome)
+        run: pnpm --filter @marimo/extension zip
+
+      # Also emits the sources ZIP that AMO requires for reviewing bundled code.
+      - name: Build & zip (Firefox)
+        run: pnpm --filter @marimo/extension zip:firefox
+
+      - name: Validate Firefox build (web-ext lint)
+        run: pnpm --filter @marimo/extension exec web-ext lint --source-dir output/firefox-mv2 --self-hosted
+
+      # The Web Store verifies uploads against the public key registered under
+      # Verified CRX Uploads, so the package must be signed with its private half
+      # or the dashboard rejects it.
+      - name: Sign the Chrome package
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          if [ -z "$CRX_PRIVATE_KEY" ]; then
+            echo "::error::CRX_PRIVATE_KEY is not set on the release environment."
+            exit 1
+          fi
+          # Written outside the workspace so it cannot be picked up by a later
+          # step that globs the repo, and so it dies with the runner.
+          key="$RUNNER_TEMP/crx.pem"
+          printf '%s' "$CRX_PRIVATE_KEY" | base64 --decode >"$key"
+          scripts/pack-crx.sh \
+            --key "$key" \
+            --out "apps/extension/output/marimo-glance-${{ steps.version.outputs.version }}.crx"
+
+      - name: Create draft release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Draft, so the generated notes can be rewritten and the assets checked
+          # before any watcher is notified. The Chrome ZIP is deliberately left
+          # out: verified uploads take the signed CRX, and offering both invites
+          # uploading the wrong one.
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --target "$GITHUB_SHA" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --draft \
+            --generate-notes \
+            "apps/extension/output/marimo-glance-$VERSION.crx" \
+            "apps/extension/output/marimo-glance-$VERSION-firefox.zip" \
+            "apps/extension/output/marimo-glance-$VERSION-sources.zip"
+
+      - name: Upload artifacts (dry run)
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-artifacts
+          path: |
+            apps/extension/output/marimo-glance-*.crx
+            apps/extension/output/marimo-glance-*-firefox.zip
+            apps/extension/output/marimo-glance-*-sources.zip
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ source archive submitted to Firefox Add-ons.
 Requirements:
 
 - Node.js 24
-- pnpm 11.11.0 — pinned in the root `package.json` `"packageManager"` field, so
+- pnpm — pinned in the root `package.json` `"packageManager"` field, so
   `corepack enable` selects the right version automatically.
 
 ```bash
@@ -68,6 +68,36 @@ it makes the bundler fail to resolve those imports.
 To produce the uploadable archives instead of an unpacked build, use
 `pnpm --filter @marimo/extension zip` (Chrome) or `zip:firefox` (Firefox); the
 Firefox command also emits a `-sources.zip` of this monorepo.
+
+## Releasing
+
+Releases are cut by maintainers from `main` with the **Release** workflow
+(Actions → Release → Run workflow). The version comes from
+`apps/extension/package.json`, so bump it in a PR and merge that first; the
+workflow refuses to run if a tag for the version already exists.
+
+The run pauses for approval on the `release` environment, then builds both
+browser packages, signs the Chrome one, and opens a **draft** GitHub release
+tagged `v<version>` with three assets:
+
+| Asset                                 | Goes to                                                          |
+| ------------------------------------- | ---------------------------------------------------------------- |
+| `marimo-glance-<version>.crx`         | Chrome Web Store — _Package → Upload new package_                |
+| `marimo-glance-<version>-firefox.zip` | Firefox Add-ons — _Upload New Version_                           |
+| `marimo-glance-<version>-sources.zip` | Firefox Add-ons, when it asks for the sources of a bundled build |
+
+Edit the generated notes, publish the release, then upload the two packages to
+the stores by hand. Tick **dry run** to exercise the whole pipeline without
+creating a tag or release — the artifacts are attached to the workflow run
+instead.
+
+The Chrome package is signed because the listing uses
+[Verified CRX Uploads](https://developer.chrome.com/blog/verified-uploads-cws):
+the dashboard checks the signature against a registered public key and rejects
+anything else, then repackages with Google's own key before publishing. The
+private half lives in the `CRX_PRIVATE_KEY` secret on the `release` environment,
+base64-encoded. `scripts/pack-crx.sh --help` documents signing a package locally
+with the same key.
 
 ## Repository layout
 

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   // `pnpm install` and reproduce the build. Zip from the repo root and drop
   // only generated artifacts (node_modules and dotfiles are excluded by default).
   zip: {
+    // Without this the archives are named after the package (`@marimo/extension`
+    // kebab-cased to `marimoextension`). Store reviewers download these by name.
+    name: "marimo-glance",
     sourcesRoot: "../..",
     excludeSources: ["**/dist/**", "**/output/**", "**/.wxt/**", "**/.turbo/**"],
   },


### PR DESCRIPTION
## What

Adds a manually-triggered **Release** workflow that builds both browser packages, signs the Chrome one, and opens a draft GitHub release carrying everything the two store uploads need.

Releasing was previously entirely by hand and undocumented: no release workflow existed, `scripts/pack-crx.sh` was referenced nowhere, and the single `v0.1.2` tag had no GitHub release behind it. Store uploads stay manual — the Chrome Web Store API documents ZIP uploads only, which is not what a [verified-uploads](https://developer.chrome.com/blog/verified-uploads-cws) listing accepts.

## How it works

Actions → **Release** → Run workflow, from `main`. The version comes from `apps/extension/package.json`, so the bump lands in its own PR first.

1. Aborts immediately if `v<version>` is already tagged
2. Pauses for approval on the `release` environment
3. Builds, zips both browsers, runs `web-ext lint`
4. Decodes `CRX_PRIVATE_KEY` to `$RUNNER_TEMP` and signs the Chrome build
5. Creates a **draft** release tagged `v<version>` with three assets

| Asset | Destination |
| --- | --- |
| `marimo-glance-<version>.crx` | Chrome Web Store — *Package → Upload new package* |
| `marimo-glance-<version>-firefox.zip` | Firefox Add-ons — *Upload New Version* |
| `marimo-glance-<version>-sources.zip` | Firefox Add-ons, for reviewing the bundled build |

The Chrome ZIP is built but not attached: verified uploads take the signed CRX, and shipping both invites uploading the wrong one.

**Dry run** ticked runs everything including signing, but creates no tag and no release — artifacts go to the workflow run instead.

## Decisions worth reviewing

**No test re-run in the release job.** `main` is already gated by CI, so the release job builds and signs only. It does keep `web-ext lint`, since that validates the packaged output rather than the source.

**No release-notes generator.** `--generate-notes` into a draft that gets rewritten by hand. A generator keyed on conventional-commit prefixes was considered and dropped — at this repo's cadence the generated list is most of what it would produce, and marimo's own `generate_release_notes.py` is unwired and hand-run for exactly that reason.

**Key scoping.** `CRX_PRIVATE_KEY` lives on the `release` environment, not the repository, so only an approved run can read it. The environment also restricts deployments to protected branches, meaning the workflow can only be dispatched from `main`.

**Archive naming.** `zip.name` is set because WXT derived names from the package (`marimoextension-0.1.2-sources.zip`) — that name is what an AMO reviewer downloads.

## Verification

Everything testable without the real key and dashboard was run locally:

- Both zip commands produce exactly the filenames the workflow references: `marimo-glance-0.1.2-{chrome,firefox,sources}.zip`
- Signing verified end to end with a throwaway RSA key through the workflow's exact `printf '%s' "$VAR" | base64 --decode` path (`cmp` confirms a byte-identical roundtrip), then `pack-crx.sh --key --out` produced a valid CRX at the versioned path
- Workflow YAML parses; both `if:` conditions resolve to the intended steps
- `pnpm format`, `pnpm lint` pass

Remaining, after merge:

1. Dispatch with **dry run** → approve the gate → confirm three assets, no tag, no release
2. Bump to `0.2.0` (the merged self-hosted-hosts work in #25 needs it) and dispatch for real
3. Upload the CRX to the dashboard — the only step that proves a CI-signed package satisfies verified uploads

Also drops the stale `pnpm 11.11.0` from CONTRIBUTING, which went out of date when Renovate bumped it in #16.
