### PR TITLE
chore: bump to 0.2.0 and document release tag timing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,10 @@ the stores by hand. Tick **dry run** to exercise the whole pipeline without
 creating a tag or release — the artifacts are attached to the workflow run
 instead.
 
+The tag is created when the packages are built, not when they reach the stores.
+If a store rejects an upload, delete the tag and the draft release before
+re-running.
+
 The Chrome package is signed because the listing uses
 [Verified CRX Uploads](https://developer.chrome.com/blog/verified-uploads-cws):
 the dashboard checks the signature against a registered public key and rejects

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marimo/extension",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Bumps the extension to `0.2.0` so a release can be cut, and documents when the release tag is created.

`0.1.2` is what is published to both stores, and it predates the self-hosted GitHub and GitLab support merged in #25. The release workflow reads the version from `apps/extension/package.json` and aborts if `v<version>` is already tagged, so the bump has to land before a release can run.

Minor rather than patch: #25 added user-facing capability, and it introduced the `storage` and `scripting` permissions plus an `optional_host_permissions` entry. Existing users will see a grant prompt the first time they enable a host, which is not patch-level behaviour.

## The tag timing note

`CONTRIBUTING.md` described the release as done once the draft exists. It isn't — the workflow tags at build time, and the store uploads happen afterwards by hand, so a tag can outlive an upload that a dashboard rejected.

This is a deliberate tradeoff rather than a defect. The alternative is to split the workflow in two and only tag after a confirmed publish, so a tag always means "this shipped". For a solo-maintained extension that is more machinery than the property is worth, so the tag means "this was built" and the recovery step is now written down instead of living in someone's head.

## Verification

- `pnpm format`, `pnpm lint` pass
- A full build produces `marimo-glance-0.2.0-{chrome,firefox,sources}.zip` and `"version":"0.2.0"` in the Firefox manifest, confirming the filenames the release workflow references still resolve after the bump

The `@marimo/*` libraries stay at `0.0.0` — all `private: true` and unpublished, so only the extension carries a real version.

## After merge

1. Dispatch **Release** with dry run ticked, approve the `release` environment gate, confirm three assets and that no tag was created
2. Dispatch for real, edit the generated notes, publish the draft
3. Upload the CRX to the Chrome dashboard and the XPI plus sources to AMO — the CRX upload is the first real test that a CI-signed package satisfies verified uploads
