### PR TITLE
chore(renovate): batch updates monthly and age releases 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>marimo-team/.github:renovate-config"]
+  "extends": ["local>marimo-team/.github:renovate-config", "schedule:monthly"],
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 0,
+  "abandonmentThreshold": null,
+  "lockFileMaintenance": {
+    "automerge": true
+  },
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"],
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pin", "pinDigest", "digest", "patch", "minor"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Reduces Renovate PR volume and adds supply-chain protection against package poisoning.

## What changes

- **`schedule:monthly`** — updates arrive in one predictable batch instead of a continuous stream. Same cadence `marimo/marimo` uses.
- **`minimumReleaseAge: "7 days"`** — Renovate will not propose a version published within the last week. A compromised npm release is usually yanked within hours, so this filters most package-poisoning attacks without needing a human to spot them.
- **Automerge for pin/digest/patch/minor** on green CI. Majors still require review.
- **`prConcurrentLimit: 3`** — caps how much can be open at once.
- **`abandonmentThreshold: null`** — drops the dashboard's "Abandoned Dependencies" section. It flagged `clsx`, `class-variance-authority` and `lz-string`, which are stable rather than unmaintained.
- **`vulnerabilityAlerts`** opts out of both the schedule and the age floor, so a real CVE fix is not delayed by a week.

## Why PRs were piling up

The shared `marimo-team/.github:renovate-config` sets no schedule, no release-age floor and no automerge. Separately, the default-branch ruleset requires 1 approving review with an empty `bypass_actors` list, so Renovate could never merge anything — five PRs sat green and `BLOCKED`. Automerge here only works once Renovate is added to that bypass list.

## Follow-up: pnpm-level floor

The stronger version of this protection is `minimumReleaseAge` in `pnpm-workspace.yaml`, which blocks *installing* anything too new — including transitive deps and manual `pnpm add`, neither of which Renovate covers.

It cannot land yet. Four `package.json` floors point at releases younger than 7 days, so a fresh resolution fails:

```
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 349 versions do not meet the minimumReleaseAge constraint
  oxfmt@0.61.0         published 2026-07-27
  shadcn@4.16.0        published 2026-07-27
  lucide-react@1.27.0  published 2026-07-25
  radix-ui@1.6.7       published 2026-07-24
```

Regenerating the lockfile does not help — no older version satisfies those caret ranges. They mature on 2026-08-03, after which this becomes a one-line follow-up. Once Renovate refuses to propose anything under 7 days, package.json floors can no longer outrun the pnpm policy.

## Verification

- `python3 -c "import json; json.load(open(\"renovate.json\"))"` passes.
- After merge, tick **"Check this box to trigger a request for Renovate to run again"** on #4. Confirm the dashboard's "Abandoned Dependencies" section is gone and that #26, #27 and #22 automerge on green CI.
- Confirm #24 (jsdom v30, a major) stays open awaiting review.