### PR TITLE
fix(notebook-core): detect notebooks whose App() sits past the first 4 KB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ The extension passes the host to `createRuntime(host)`, which handles detection,
 
 ### `@marimo/notebook-core`
 
-- `isMarimoNotebook(source)`: detect marimo notebook from first 4096 chars
+- `isMarimoNotebook(source)`: detect marimo notebook from first 16 KB
 - `isPythonPath(path)`: check if path ends `.py`
 - `playgroundUrl(source, opts?)`: compress notebook, return marimo.app URL with `embed=true`
 - `renderNotebookAsIframe(source, opts?)`: build iframe DOM subtree

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ marimo notebooks are just Python files, so GitHub and gists show them as source 
 
 ## How it works
 
-The extension watches the pages you open on GitHub and gists. On a `.py` file it reads the source and looks for a real top-level `app = marimo.App(...)` declaration (whitespace and a type annotation are fine, and it honors `import marimo as <alias>`), scanning only the first 4 KB. A passing mention of marimo in a comment, a string, or a nested function doesn't count, so ordinary Python files are left completely alone.
+The extension watches the pages you open on GitHub and gists. On a `.py` file it reads the source and looks for a real top-level `app = marimo.App(...)` declaration (whitespace and a type annotation are fine, and it honors `import marimo as <alias>`), scanning the first 16 KB and stopping as soon as it finds a match. A passing mention of marimo in a comment, a string, or a nested function doesn't count, so ordinary Python files are left completely alone.
 
 When it does find a notebook, it drops the **"Switch to interactive marimo notebook"** button in the bottom-right corner. Clicking it boots the notebook live through [marimo.app](https://marimo.app), running entirely in WebAssembly inside your browser, right where the code was. **"See original"** flips back to the raw source, and switching between the two never restarts the notebook once it is running.
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marimo/extension",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/notebook-core/README.md
+++ b/packages/notebook-core/README.md
@@ -6,7 +6,7 @@ Keeping it this clean is the point: it could just as easily back a different too
 
 ## What you can import
 
-- `isMarimoNotebook(source)` tells you whether some Python source is a marimo notebook. It looks for a real top-level `app = marimo.App(...)` (whitespace and a type annotation are fine, and it honors an `import marimo as <alias>`) within the first 4 KB. A stray mention of marimo in a comment, a string, or a nested function won't fool it.
+- `isMarimoNotebook(source)` tells you whether some Python source is a marimo notebook. It looks for a real top-level `app = marimo.App(...)` (whitespace and a type annotation are fine, and it honors an `import marimo as <alias>`) within the first 16 KB, returning as soon as it finds a match. A stray mention of marimo in a comment, a string, or a nested function won't fool it.
 - `isPythonPath(path)` is the obvious `.py` check.
 - `playgroundUrl(source, { ref?, theme? })` builds the marimo.app embed URL, compressing the notebook into the `#code/` hash.
 - `renderNotebookAsIframe(source, options)` gives you the notebook iframe as a DOM node.

--- a/packages/notebook-core/src/detect.ts
+++ b/packages/notebook-core/src/detect.ts
@@ -61,13 +61,15 @@ function stripStringsAndComments(source: string): string {
   return result;
 }
 
+const DETECT_MAX_SIZE = 16_384;
+
 export function isPythonPath(path: string): boolean {
   return path.endsWith(".py");
 }
 
 export function isMarimoNotebook(source: string): boolean {
   const aliases = new Set([DEFAULT_ALIAS]);
-  const header = stripStringsAndComments(source.slice(0, 4096));
+  const header = stripStringsAndComments(source.slice(0, DETECT_MAX_SIZE));
 
   for (const line of header.split(/\r?\n/)) {
     if (line.startsWith(" ") || line.startsWith("\t")) {

--- a/packages/notebook-core/test/notebook-core.test.mjs
+++ b/packages/notebook-core/test/notebook-core.test.mjs
@@ -77,6 +77,24 @@ test("ignores an aliased import after the first 4 KiB", () => {
   assert.equal(isMarimoNotebook(source), true);
 });
 
+test("recognizes a notebook whose app declaration is after the first 4 KiB", () => {
+  const source = `"""${"x".repeat(4096)}"""\nimport marimo\napp = marimo.App()\n`;
+
+  assert.equal(isMarimoNotebook(source), true);
+});
+
+test("recognizes a notebook whose app declaration is after 12 KiB", () => {
+  const source = `"""${"x".repeat(12_000)}"""\nimport marimo\napp = marimo.App()\n`;
+
+  assert.equal(isMarimoNotebook(source), true);
+});
+
+test("does not scan past 16 KiB", () => {
+  const source = `"""${"x".repeat(16_384)}"""\nimport marimo\napp = marimo.App()\n`;
+
+  assert.equal(isMarimoNotebook(source), false);
+});
+
 test("identifies Python paths by extension", () => {
   assert.equal(isPythonPath("notebooks/demo.py"), true);
   assert.equal(isPythonPath("README.md"), false);


### PR DESCRIPTION
## Summary
- Scan the first 16 KB (was 4 KB) when detecting a marimo notebook, returning as soon as a real top-level `app = …App(` is found.

Made with [Cursor](https://cursor.com)